### PR TITLE
Expose asynchttpserver maxBody setting

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -420,7 +420,7 @@ proc handleRequest(jes: Jester, httpReq: NativeRequest): Future[void] =
 
 proc newSettings*(
   port = Port(5000), staticDir = getCurrentDir() / "public",
-  appName = "", bindAddr = "", reusePort = false,
+  appName = "", bindAddr = "", reusePort = false, maxBody = 8388608,
   futureErrorHandler: proc (fut: Future[void]) {.closure, gcsafe.} = nil
 ): Settings =
   result = Settings(
@@ -429,6 +429,7 @@ proc newSettings*(
     port: port,
     bindAddr: bindAddr,
     reusePort: reusePort,
+    maxBody: maxBody,
     futureErrorHandler: futureErrorHandler
   )
 
@@ -530,7 +531,7 @@ proc serve*(
       httpbeast.initSettings(self.settings.port, self.settings.bindAddr, self.settings.numThreads)
     )
   else:
-    self.httpServer = newAsyncHttpServer(reusePort=self.settings.reusePort)
+    self.httpServer = newAsyncHttpServer(reusePort=self.settings.reusePort, maxBody=self.settings.maxBody)
     let serveFut = self.httpServer.serve(
       self.settings.port,
       proc (req: asynchttpserver.Request): Future[void] {.gcsafe, closure.} =

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -16,6 +16,7 @@ type
     port*: Port
     bindAddr*: string
     reusePort*: bool
+    maxBody*: int
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
     numThreads*: int # Only available with Httpbeast (`useHttpBeast = true`)
 


### PR DESCRIPTION
This commit exposes the maxBody setting of asynchttpserver. The default value is 8388608, which is about 8MB and is taken from the nim documentation.